### PR TITLE
Setup PLG Stack (Alloy, Loki, Grafana) and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
 # Dots
 
-Here're all of my configuration files I used every day. Managed by
-[home-manager](https://github.com/nix-community/home-manager).
+My homelab and configuration files managed with NixOS, Snowfall Lib, and [home-manager](https://github.com/nix-community/home-manager).
 
-### Programs I use
+## Homelab Machines
 
-I use mostly common programs that you are probably familiar of. But I also use
-some custom software, check it out in
-[pnpkgs](https://github.com/pniedzwiedzinski/pnpkgs). And I configure vim in
-[pnvf](https://github.com/pniedzwiedzinski/pnvf).
+This repository contains the configuration for several machines in my homelab:
+
+- **t14**: My main laptop (Lenovo ThinkPad T14 AMD Gen 2). Configured with GNOME and Hyprland.
+- **srv3**: Main server. Hosts various applications, utilizes impermanence. Also runs the central monitoring stack (Grafana, Loki) and collects backups.
+- **srv2**: Raspberry Pi 3B. Acts as a "KVM" and wake-on-LAN controller for `srv5` based on network traffic.
+- **srv5**: Compute server running Ollama and other AI tasks. Controlled by `srv2`.
+- **srv4**: Offline. Originally intended to serve static files to the public internet but currently inactive.
+- **backup**: Remote backup target (via BorgBackup).
+
+## Network
+
+The homelab machines are connected securely using [Tailscale](https://tailscale.com/). Local services can be accessed using their machine hostname within the Tailscale network (e.g., `srv3`).
+
+## Monitoring & Logs
+
+A centralized logging and alerting system is deployed using the PLG stack:
+- **Alloy**: Runs on each server (`srv2`, `srv3`, `srv5`) to collect logs from `systemd-journald`.
+- **Loki**: Runs on `srv3` to aggregate logs sent by Alloy.
+- **Grafana**: Runs on `srv3` (port 3000) for visualization and alerting. Alerts for failed backup jobs are sent via Telegram.
+
+## Deployment
+
+Deployments are managed via `deploy-rs`. To apply changes to a machine, run:
+
+```bash
+nix run github:serokell/deploy-rs -- .#<hostname>
+```
+
+For example, to deploy to `srv3`:
+
+```bash
+nix run github:serokell/deploy-rs -- .#srv3
+```

--- a/modules/nixos/alloy/default.nix
+++ b/modules/nixos/alloy/default.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.dots.services.alloy;
+in {
+  options.dots.services.alloy = {
+    enable = mkEnableOption "Enable Grafana Alloy for log collection";
+
+    lokiEndpoint = mkOption {
+      type = types.str;
+      default = "http://srv3:3100/loki/api/v1/push";
+      description = "The endpoint of the Loki server to send logs to.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.alloy = {
+      enable = true;
+      configPath = pkgs.writeText "alloy-config.alloy" ''
+        loki.source.journal "read" {
+          forward_to = [
+            loki.relabel.journal.receiver,
+          ]
+          labels = {
+            component = "loki.source.journal",
+          }
+        }
+
+        loki.relabel "journal" {
+          forward_to = [
+            loki.write.endpoint.receiver,
+          ]
+
+          rule {
+            source_labels = ["__journal__systemd_unit"]
+            target_label  = "unit"
+          }
+          rule {
+            source_labels = ["__journal__hostname"]
+            target_label  = "host"
+          }
+        }
+
+        loki.write "endpoint" {
+          endpoint {
+            url = "${cfg.lokiEndpoint}"
+          }
+        }
+      '';
+    };
+  };
+}

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -40,6 +40,17 @@ in {
             }
           ];
         };
+
+        limits_config = {
+          retention_period = "120d";
+        };
+
+        compactor = {
+          working_directory = "/var/lib/loki/compactor";
+          retention_enabled = true;
+          retention_delete_delay = "2h";
+          retention_delete_worker_count = 150;
+        };
       };
     };
 

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -57,6 +57,7 @@ in {
         datasources.settings.datasources = [
           {
             name = "Loki";
+            uid = "Loki";
             type = "loki";
             access = "proxy";
             url = "http://127.0.0.1:3100";
@@ -83,14 +84,15 @@ in {
             ];
           };
 
+          policies.settings.policies = [
+            {
+              orgId = 1;
+              receiver = "TelegramContact";
+              group_by = ["alertname"];
+            }
+          ];
+
           rules.settings = {
-            policies = [
-              {
-                orgId = 1;
-                receiver = "TelegramContact";
-                group_by = ["alertname"];
-              }
-            ];
             groups = [
               {
                 name = "BackupAlerts";

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.dots.services.monitoring;
+in {
+  options.dots.services.monitoring = {
+    enable = mkEnableOption "Enable Central Monitoring (Loki and Grafana)";
+  };
+
+  config = mkIf cfg.enable {
+    services.loki = {
+      enable = true;
+      configuration = {
+        server.http_listen_port = 3100;
+        auth_enabled = false;
+
+        common = {
+          ring = {
+            instance_addr = "0.0.0.0";
+            kvstore.store = "inmemory";
+          };
+          replication_factor = 1;
+          path_prefix = "/var/lib/loki";
+        };
+
+        schema_config = {
+          configs = [
+            {
+              from = "2020-10-24";
+              store = "tsdb";
+              object_store = "filesystem";
+              schema = "v13";
+              index = {
+                prefix = "index_";
+                period = "24h";
+              };
+            }
+          ];
+        };
+      };
+    };
+
+    services.grafana = {
+      enable = true;
+      settings = {
+        server = {
+          http_addr = "0.0.0.0";
+          http_port = 3000;
+        };
+      };
+
+      provision = {
+        enable = true;
+        datasources.settings.datasources = [
+          {
+            name = "Loki";
+            type = "loki";
+            access = "proxy";
+            url = "http://127.0.0.1:3100";
+            isDefault = true;
+          }
+        ];
+
+        alerting = {
+          contactPoints = {
+            settings.contactPoints = [
+              {
+                name = "TelegramContact";
+                receivers = [
+                  {
+                    uid = "telegram-receiver-1";
+                    type = "telegram";
+                    settings = {
+                      bottoken = "\${TELEGRAM_BOT_TOKEN}"; # To be replaced by Agenix/Sops
+                      chatid = "\${TELEGRAM_CHAT_ID}";
+                    };
+                  }
+                ];
+              }
+            ];
+          };
+
+          rules.settings = {
+            policies = [
+              {
+                orgId = 1;
+                receiver = "TelegramContact";
+                group_by = ["alertname"];
+              }
+            ];
+            groups = [
+              {
+                name = "BackupAlerts";
+                orgId = 1;
+                folder = "Alerts";
+                interval = "5m";
+                rules = [
+                  {
+                    uid = "backup-failure-1";
+                    title = "BorgBackup Job Failed";
+                    condition = "A";
+                    data = [
+                      {
+                        refId = "A";
+                        datasourceUid = "Loki";
+                        model = {
+                          editorMode = "code";
+                          expr = ''count_over_time({unit=~"borgbackup-.*"} |~ "(?i)(error|failed|fatal)" [5m]) > 0'';
+                          queryType = "range";
+                        };
+                      }
+                    ];
+                    noDataState = "OK";
+                    execErrState = "Error";
+                    for = "5m";
+                    annotations = {
+                      summary = "A BorgBackup job has failed.";
+                      description = "Errors detected in BorgBackup journald logs over the last 5 minutes.";
+                    };
+                  }
+                ];
+              }
+            ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -50,6 +50,7 @@ in {
           retention_enabled = true;
           retention_delete_delay = "2h";
           retention_delete_worker_count = 150;
+          delete_request_store = "filesystem";
         };
       };
     };

--- a/systems/aarch64-linux/srv2/configuration.nix
+++ b/systems/aarch64-linux/srv2/configuration.nix
@@ -15,6 +15,8 @@
   srv.enable = true;
   system.autoUpgrade.enable = false;
 
+  dots.services.alloy.enable = true;
+
   # Partition for config.txt and other overlays
   fileSystems."/boot/firmware" = {
     device = "/dev/disk/by-label/FIRMWARE";

--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -24,6 +24,9 @@ in
     machineId = "srv3";
   };
 
+  dots.services.monitoring.enable = true;
+  dots.services.alloy.enable = true;
+
   services.openssh = {
     enable = true;
     ports = lib.mkForce [ 19 ];
@@ -45,6 +48,8 @@ in
     19
     80
     443
+    3000 # grafana
+    3100 # loki
     8123
   ];
 

--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -48,9 +48,12 @@ in
     19
     80
     443
+    8123
+  ];
+
+  networking.firewall.interfaces."tailscale0".allowedTCPPorts = [
     3000 # grafana
     3100 # loki
-    8123
   ];
 
   time.timeZone = "Europe/Warsaw";
@@ -191,6 +194,10 @@ in
             {
               name = "research";
               port = "3001";
+            }
+            {
+              name = "grafana";
+              port = "3000";
             }
           ];
         };

--- a/systems/x86_64-linux/srv3/persist.nix
+++ b/systems/x86_64-linux/srv3/persist.nix
@@ -43,6 +43,18 @@
           group = "acme";
           mode = "0755";
         }
+        {
+          directory = "/var/lib/grafana";
+          user = "grafana";
+          group = "grafana";
+          mode = "0700";
+        }
+        {
+          directory = "/var/lib/loki";
+          user = "loki";
+          group = "loki";
+          mode = "0700";
+        }
         "/srv"
       ];
       files = [

--- a/systems/x86_64-linux/srv5/configuration.nix
+++ b/systems/x86_64-linux/srv5/configuration.nix
@@ -15,6 +15,8 @@
     machineId = "srv5";
   };
 
+  dots.services.alloy.enable = true;
+
   disko.devices.disk.main.device = "/dev/sda";
 
   services.openssh = {


### PR DESCRIPTION
This PR implements a centralized log collection and alerting system for the homelab using the PLG stack (Promtail's successor Alloy + Loki + Grafana), as requested.

### Key Changes
1. **New `dots.services.alloy` Module:** Configured to gather logs from `systemd-journald` and forward them to the Loki instance on `srv3`. Enabled on all servers (`srv2`, `srv3`, `srv5`) but explicitly omitted from the laptop (`t14`).
2. **New `dots.services.monitoring` Module:** Configured on `srv3`. Starts Loki (for log aggregation) and Grafana (for dashboards and alerts).
3. **Alerting:** Provisioned a Telegram Contact Point in Grafana (using placeholders for `agenix` secrets) and set up an alert rule specifically to detect failures in `borgbackup` systemd units.
4. **README Update:** Rewrote `README.md` to remove outdated information and clearly document the roles of each homelab machine, the use of Tailscale, the new monitoring stack, and the deployment procedure using `deploy-rs`.

---
*PR created automatically by Jules for task [7185520069139217046](https://jules.google.com/task/7185520069139217046) started by @pniedzwiedzinski*