### PR TITLE
chore: migrate hermes agent to oci-containers

### DIFF
--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -19,6 +19,7 @@ in
     ./grafana.nix
     ./nginx.nix
     ./cloudflared.nix
+    ./hermes.nix
   ];
 
   disko.devices.disk.main.device = "/dev/sdb";

--- a/systems/x86_64-linux/srv3/hermes.nix
+++ b/systems/x86_64-linux/srv3/hermes.nix
@@ -1,0 +1,41 @@
+{ lib, ... }: {
+  # Hermes Agent — AI coding assistant (Nous Research)
+  # Runs as Docker container managed by NixOS via oci-containers
+  # Traefik reverse proxy: hermes.srv3.niedzwiedzinski.cyou → localhost:8642
+
+  # --- Docker container via NixOS ---
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers.hermes = {
+      autoStart = true;
+      image = "nousresearch/hermes-agent:latest";
+      cmd = [ "gateway", "run" ];
+      ports = [ "127.0.0.1:8642:8642" ];
+      volumes = [
+        "/srv/hermes/data:/opt/data"
+      ];
+      environment = {
+        HERMES_HOME = "/opt/data";
+      };
+      extraOptions = [
+        "--pull=always"
+      ];
+    };
+  };
+
+  # --- Traefik routing ---
+  services.traefik.dynamicConfigOptions = lib.mkAfter {
+    http.services.hermes = {
+      loadBalancer.servers = [{ url = "http://localhost:8642"; }];
+    };
+    http.routers.hermes = {
+      entryPoints = [ "websecure" ];
+      rule = "Host(`hermes.srv3.niedzwiedzinski.cyou`)";
+      service = "hermes";
+      tls.certResolver = "letsencrypt";
+    };
+  };
+
+  # Allow direct Tailscale access for CLI usage
+  networking.firewall.interfaces."tailscale0".allowedTCPPorts = [ 8642 ];
+}


### PR DESCRIPTION
Migrates the Hermes agent deployment from docker-compose to NixOS `oci-containers`. This involves updating `hermes.nix` to use `virtualisation.oci-containers` with the appropriate configuration and removing the now obsolete `docker-compose.yml` file.

---
*PR created automatically by Jules for task [15769317588550517576](https://jules.google.com/task/15769317588550517576) started by @pniedzwiedzinski*