### PR TITLE
feat(srv3): add hermes agent via nixos containers

### DIFF
--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -19,6 +19,7 @@ in
     ./grafana.nix
     ./nginx.nix
     ./cloudflared.nix
+    ./hermes.nix
   ];
 
   disko.devices.disk.main.device = "/dev/sdb";

--- a/systems/x86_64-linux/srv3/hermes.nix
+++ b/systems/x86_64-linux/srv3/hermes.nix
@@ -1,0 +1,31 @@
+{ lib, ... }: {
+  # Hermes Agent — AI coding assistant (Nous Research)
+  # Docker container via NixOS oci-containers, Traefik reverse proxy
+
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers.hermes = {
+      autoStart = true;
+      image = "nousresearch/hermes-agent:latest";
+      cmd = [ "gateway", "run" ];
+      ports = [ "127.0.0.1:8642:8642" ];
+      volumes = [ "/srv/hermes/data:/opt/data" ];
+      environment = { HERMES_HOME = "/opt/data"; };
+      extraOptions = [ "--pull=always" ];
+    };
+  };
+
+  services.traefik.dynamicConfigOptions = lib.mkAfter {
+    http.services.hermes = {
+      loadBalancer.servers = [{ url = "http://localhost:8642"; }];
+    };
+    http.routers.hermes = {
+      entryPoints = [ "websecure" ];
+      rule = "Host(`hermes.srv3.niedzwiedzinski.cyou`)";
+      service = "hermes";
+      tls.certResolver = "letsencrypt";
+    };
+  };
+
+  networking.firewall.interfaces."tailscale0".allowedTCPPorts = [ 8642 ];
+}


### PR DESCRIPTION
Adds the declarative NixOS deployment for the Hermes AI coding assistant on srv3.

---
*PR created automatically by Jules for task [1439899500720612528](https://jules.google.com/task/1439899500720612528) started by @pniedzwiedzinski*