### PR TITLE
fix: serve all Traefik services over HTTPS on srv3

### DIFF
--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -106,11 +106,11 @@ in
         entryPoints = {
           web = {
             address = "0.0.0.0:80";
-            # http.redirections.entryPoint = {
-            #   to = "websecure";
-            #   scheme = "https";
-            #   permanent = true;
-            # };
+            http.redirections.entryPoint = {
+              to = "websecure";
+              scheme = "https";
+              permanent = true;
+            };
           };
 
           websecure = {
@@ -133,7 +133,7 @@ in
             loadBalancer.servers = [ { url = "http://localhost:" + service.port; } ];
           };
           generateRouter = service: {
-            entryPoints = [ "web" ];
+            entryPoints = [ "websecure" ];
             rule = "Host(`" + service.name + ".${config.srv.machineId}.${domain}`)";
             service = service.name;
           };


### PR DESCRIPTION
- Changed the default entrypoint for dynamically generated Traefik routers to `websecure` in `systems/x86_64-linux/srv3/configuration.nix`.
- Uncommented the HTTP-to-HTTPS redirect block on port 80 to enforce HTTPS.

---
*PR created automatically by Jules for task [13577104756895947917](https://jules.google.com/task/13577104756895947917) started by @pniedzwiedzinski*