### PR TITLE
Update Hermes Agent to official NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,8 @@
 
     deploy-rs.url = "github:serokell/deploy-rs";
 
+    hermes-agent.url = "github:NousResearch/hermes-agent";
+
     snowfall-lib = {
       url = "github:snowfallorg/lib";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -203,10 +203,6 @@ in
             }
             {
               name = "workspace";
-              port = "3002";
-            }
-            {
-              name = "hermes";
               port = "9119";
             }
           ];

--- a/systems/x86_64-linux/srv3/default.nix
+++ b/systems/x86_64-linux/srv3/default.nix
@@ -3,6 +3,7 @@
   imports = with inputs; [
     disko.nixosModules.disko
     impermanence.nixosModules.impermanence
+    hermes-agent.nixosModules.default
     ./hardware-configuration.nix
     ./configuration.nix
   ];

--- a/systems/x86_64-linux/srv3/hermes.nix
+++ b/systems/x86_64-linux/srv3/hermes.nix
@@ -3,73 +3,22 @@
   pkgs,
   ...
 }: {
-  # Hermes Agent — AI coding assistant (Nous Research)
-  virtualisation.oci-containers = {
-    backend = "docker";
-    containers.hermes = {
-      autoStart = true;
-      image = "nousresearch/hermes-agent:latest";
-      cmd = ["gateway" "run"];
-      ports = [
-        "127.0.0.1:8642:8642"
-        "127.0.0.1:9119:9119"
-      ];
-      volumes = ["/srv/hermes/data:/opt/data"];
-      environment = {
-        HERMES_HOME = "/opt/data";
-        HERMES_DASHBOARD = "1";
-        API_SERVER_ENABLED = "true";
-        API_SERVER_HOST = "0.0.0.0";
-        API_SERVER_KEY = "b8197597fce4b84c3fa14a1462d51f1790d6e0a51cc114108d332fecffc1cc1a";
-      };
-      extraOptions = [
-        "--pull=always"
-        "--network=hermes-net"
-        "--network-alias=hermes"
-      ];
-    };
-  };
+  # Hermes Agent — AI coding assistant (Nous Research) via official NixOS module
+  services.hermes-agent = {
+    enable = true;
+    container.enable = true;
 
-  # Hermes Workspace — web UI for Hermes Agent
-  virtualisation.oci-containers.containers."hermes-workspace" = {
-    autoStart = true;
-    image = "ghcr.io/outsourc-e/hermes-workspace:latest";
-    ports = ["127.0.0.1:3002:3000"];
-    volumes = [
-      "/srv/hermes/workspace:/workspace"
-      "/srv/hermes/data:/home/workspace/.hermes"
-    ];
+    # Przenosimy dane agenta by lądowały tam, gdzie dotychczas.
+    stateDir = "/srv/hermes/data";
+
+    # Dodajemy klucze i sekrety współdzielone w postaci pliku environmentFiles.
     environmentFiles = ["/srv/hermes/workspace.env"];
-    environment = {
-      HERMES_HOME = "/home/workspace/.hermes";
-      HERMES_WORKSPACE_DIR = "/workspace";
-      HERMES_API_URL = "http://hermes:8642";
-      HERMES_DASHBOARD_URL = "http://hermes:9119";
-      HERMES_API_TOKEN = "b8197597fce4b84c3fa14a1462d51f1790d6e0a51cc114108d332fecffc1cc1a";
-      COOKIE_SECURE = "0";
-      TRUST_PROXY = "1";
-    };
-    extraOptions = [
-      "--pull=always"
-      "--network=hermes-net"
-      "--user=10000:10000" # share folder
-    ];
-    dependsOn = ["hermes"];
-  };
 
-  # Docker network for Hermes containers
-  systemd.services."docker-network-hermes-net" = {
-    path = [pkgs.docker];
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      ExecStop = "${pkgs.docker}/bin/docker network rm -f hermes-net";
+    # Deklarujemy nie-tajne zmienne środowiskowe, które aktywują dashboard/API.
+    environment = {
+      HERMES_DASHBOARD = "1";
+      API_SERVER_ENABLED = "true";
+      API_SERVER_HOST = "0.0.0.0";
     };
-    script = ''
-      ${pkgs.docker}/bin/docker network inspect hermes-net || ${pkgs.docker}/bin/docker network create hermes-net
-    '';
-    partOf = ["docker-hermes.service"];
-    wantedBy = ["docker-hermes.service"];
-    before = ["docker-hermes.service"];
   };
 }


### PR DESCRIPTION
Zaktualizowano Hermes Agenta oraz Workspace do korzystania z nowo dostępnego, oficjalnego modułu NixOS od NousResearch. Zrezygnowano z oddzielnego dockerowego kontenera Web UI i ręcznego dockera agenta. Zamiast tego zdefiniowano moduł `hermes-agent` na tryb wbudowanego kontenera (`container.enable = true`), który wystawia zintegrowany serwer dashboard UI i serwuje pliki bezpośrednio na ten sam port (9119). Zaktualizowano też Traefika by wskazywał ten nowy port. W `flake.nix` i srv3 `default.nix` wprowadzono nową definicję modułu.

---
*PR created automatically by Jules for task [2370848850007906531](https://jules.google.com/task/2370848850007906531) started by @pniedzwiedzinski*