### PR TITLE
feat: add Actual Budget to srv3

### DIFF
--- a/systems/x86_64-linux/srv3/actual.nix
+++ b/systems/x86_64-linux/srv3/actual.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  # Actual Budget
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers.actual = {
+      autoStart = true;
+      image = "actualbudget/actual-server:latest";
+      ports = [
+        "127.0.0.1:3006:5006"
+      ];
+      volumes = ["/srv/actual/data:/data"];
+      extraOptions = [
+        "--pull=always"
+      ];
+    };
+  };
+}

--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -20,6 +20,7 @@ in
     ./nginx.nix
     ./cloudflared.nix
     ./hermes.nix
+    ./actual.nix
   ];
 
   disko.devices.disk.main.device = "/dev/sda";
@@ -208,6 +209,10 @@ in
             {
               name = "hermes";
               port = "9119";
+            }
+            {
+              name = "actual";
+              port = "3006";
             }
           ];
       };


### PR DESCRIPTION
Add Actual Budget via OCI container to srv3. Set up mapping, volume and traefik routing for actual.srv3.niedzwiedzinski.cyou domain.

---
*PR created automatically by Jules for task [3550925632324813571](https://jules.google.com/task/3550925632324813571) started by @pniedzwiedzinski*