### PR TITLE
feat(srv3): add Actual Budget service

### DIFF
--- a/systems/x86_64-linux/srv3/actual.nix
+++ b/systems/x86_64-linux/srv3/actual.nix
@@ -1,0 +1,16 @@
+{
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers.actual = {
+      autoStart = true;
+      image = "actualbudget/actual-server:latest";
+      ports = [
+        "127.0.0.1:3006:5006"
+      ];
+      volumes = ["/srv/actual/data:/data"];
+      extraOptions = [
+        "--pull=always"
+      ];
+    };
+  };
+}

--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -20,6 +20,7 @@ in
     ./nginx.nix
     ./cloudflared.nix
     ./hermes.nix
+    ./actual.nix
   ];
 
   disko.devices.disk.main.device = "/dev/sda";
@@ -208,6 +209,10 @@ in
             {
               name = "hermes";
               port = "9119";
+            }
+            {
+              name = "actual";
+              port = "3006";
             }
           ];
       };


### PR DESCRIPTION
Adds Actual Budget to srv3.

- Creates `systems/x86_64-linux/srv3/actual.nix` with OCI container definition for Actual Budget.
- Modifies `systems/x86_64-linux/srv3/configuration.nix` to import `actual.nix` and add routing configuration in `makeServices`.

---
*PR created automatically by Jules for task [7031628574184926183](https://jules.google.com/task/7031628574184926183) started by @pniedzwiedzinski*