### PR TITLE
feat: add Firefly III to srv3

### DIFF
--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -20,6 +20,7 @@ in
     ./nginx.nix
     ./cloudflared.nix
     ./hermes.nix
+    ./firefly.nix
   ];
 
   disko.devices.disk.main.device = "/dev/sda";
@@ -208,6 +209,14 @@ in
             {
               name = "hermes";
               port = "9119";
+            }
+            {
+              name = "firefly";
+              port = "3007";
+            }
+            {
+              name = "importer";
+              port = "3008";
             }
           ];
       };

--- a/systems/x86_64-linux/srv3/firefly.nix
+++ b/systems/x86_64-linux/srv3/firefly.nix
@@ -34,7 +34,7 @@
         DB_DATABASE = "firefly";
         DB_USERNAME = "firefly";
         DB_PASSWORD = "efd4ea7ac0b68245572d2cfdfe1dc6b92acfe34c616169e2"; # Should match POSTGRES_PASSWORD
-        APP_KEY = "base64:ugLQrF38Rf8U4OmFXlodYw1eM2IkfllZ2wR8qGNZOmA=";
+        APP_KEY = "base64:uKamfqOYBbPEE7eGxTfarCWLRdsyy/VkVzIg3wKLb18=";
         TRUSTED_PROXIES = "**";
         SITE_OWNER = "patryk@niedzwiedzinski.cyou";
         TZ = "Europe/Warsaw";
@@ -73,7 +73,7 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStop = "${pkgs.docker}/bin/docker network rm -f firefly-net";
+      ExecStop = "${pkgs.docker}/bin/docker network rm firefly-net";
     };
     script = ''
       ${pkgs.docker}/bin/docker network inspect firefly-net || ${pkgs.docker}/bin/docker network create firefly-net

--- a/systems/x86_64-linux/srv3/firefly.nix
+++ b/systems/x86_64-linux/srv3/firefly.nix
@@ -13,7 +13,7 @@
       environment = {
         POSTGRES_USER = "firefly";
         POSTGRES_DB = "firefly";
-        POSTGRES_PASSWORD = "efd4ea7ac0b68245572d2cfdfe1dc6b92acfe34c616169e2"; # Consider moving to agenix/environmentFiles later
+        POSTGRES_PASSWORD = "abf67942a6ea9c60cc8e7be054aef166";
       };
       extraOptions = [
         "--pull=always"
@@ -33,7 +33,7 @@
         DB_PORT = "5432";
         DB_DATABASE = "firefly";
         DB_USERNAME = "firefly";
-        DB_PASSWORD = "efd4ea7ac0b68245572d2cfdfe1dc6b92acfe34c616169e2"; # Should match POSTGRES_PASSWORD
+        DB_PASSWORD = "abf67942a6ea9c60cc8e7be054aef166";
         APP_KEY = "base64:uKamfqOYBbPEE7eGxTfarCWLRdsyy/VkVzIg3wKLb18=";
         TRUSTED_PROXIES = "**";
         SITE_OWNER = "patryk@niedzwiedzinski.cyou";

--- a/systems/x86_64-linux/srv3/firefly.nix
+++ b/systems/x86_64-linux/srv3/firefly.nix
@@ -13,7 +13,7 @@
       environment = {
         POSTGRES_USER = "firefly";
         POSTGRES_DB = "firefly";
-        POSTGRES_PASSWORD = "firefly_db_password"; # Consider moving to agenix/environmentFiles later
+        POSTGRES_PASSWORD = "efd4ea7ac0b68245572d2cfdfe1dc6b92acfe34c616169e2"; # Consider moving to agenix/environmentFiles later
       };
       extraOptions = [
         "--pull=always"
@@ -33,10 +33,10 @@
         DB_PORT = "5432";
         DB_DATABASE = "firefly";
         DB_USERNAME = "firefly";
-        DB_PASSWORD = "firefly_db_password"; # Should match POSTGRES_PASSWORD
-        APP_KEY = "c17bb3e5e2c28bb950f08ec8e0ca58d356f7c5fd581fae06d7d23194af8d8538";
+        DB_PASSWORD = "efd4ea7ac0b68245572d2cfdfe1dc6b92acfe34c616169e2"; # Should match POSTGRES_PASSWORD
+        APP_KEY = "base64:ugLQrF38Rf8U4OmFXlodYw1eM2IkfllZ2wR8qGNZOmA=";
         TRUSTED_PROXIES = "**";
-        SITE_OWNER = "mail@example.com";
+        SITE_OWNER = "patryk@niedzwiedzinski.cyou";
         TZ = "Europe/Warsaw";
       };
       extraOptions = [

--- a/systems/x86_64-linux/srv3/firefly.nix
+++ b/systems/x86_64-linux/srv3/firefly.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  virtualisation.oci-containers = {
+    backend = "docker";
+
+    containers."firefly-db" = {
+      autoStart = true;
+      image = "postgres:16-alpine";
+      volumes = ["/srv/firefly/db:/var/lib/postgresql/data"];
+      environment = {
+        POSTGRES_USER = "firefly";
+        POSTGRES_DB = "firefly";
+        POSTGRES_PASSWORD = "firefly_db_password"; # Consider moving to agenix/environmentFiles later
+      };
+      extraOptions = [
+        "--pull=always"
+        "--network=firefly-net"
+        "--network-alias=firefly-db"
+      ];
+    };
+
+    containers.firefly = {
+      autoStart = true;
+      image = "fireflyiii/core:latest";
+      ports = ["127.0.0.1:3007:8080"];
+      volumes = ["/srv/firefly/upload:/var/www/html/storage/upload"];
+      environment = {
+        DB_CONNECTION = "pgsql";
+        DB_HOST = "firefly-db";
+        DB_PORT = "5432";
+        DB_DATABASE = "firefly";
+        DB_USERNAME = "firefly";
+        DB_PASSWORD = "firefly_db_password"; # Should match POSTGRES_PASSWORD
+        APP_KEY = "c17bb3e5e2c28bb950f08ec8e0ca58d356f7c5fd581fae06d7d23194af8d8538";
+        TRUSTED_PROXIES = "**";
+        SITE_OWNER = "mail@example.com";
+        TZ = "Europe/Warsaw";
+      };
+      extraOptions = [
+        "--pull=always"
+        "--network=firefly-net"
+        "--network-alias=firefly"
+      ];
+      dependsOn = ["firefly-db"];
+    };
+
+    containers."firefly-importer" = {
+      autoStart = true;
+      image = "fireflyiii/data-importer:latest";
+      ports = ["127.0.0.1:3008:8080"];
+      environment = {
+        FIREFLY_III_URL = "http://firefly:8080";
+        FIREFLY_III_ACCESS_TOKEN = "<PLACEHOLDER>";
+        VANITY_URL = "https://firefly.srv3.niedzwiedzinski.cyou";
+        TRUSTED_PROXIES = "**";
+        TZ = "Europe/Warsaw";
+      };
+      extraOptions = [
+        "--pull=always"
+        "--network=firefly-net"
+        "--network-alias=importer"
+      ];
+      dependsOn = ["firefly"];
+    };
+  };
+
+  # Docker network for Firefly III containers
+  systemd.services."docker-network-firefly-net" = {
+    path = [pkgs.docker];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStop = "${pkgs.docker}/bin/docker network rm -f firefly-net";
+    };
+    script = ''
+      ${pkgs.docker}/bin/docker network inspect firefly-net || ${pkgs.docker}/bin/docker network create firefly-net
+    '';
+    partOf = ["docker-firefly-db.service" "docker-firefly.service" "docker-firefly-importer.service"];
+    wantedBy = ["docker-firefly-db.service" "docker-firefly.service" "docker-firefly-importer.service"];
+    before = ["docker-firefly-db.service" "docker-firefly.service" "docker-firefly-importer.service"];
+  };
+}


### PR DESCRIPTION
This PR introduces Firefly III and its Data Importer to the `srv3` system. 
It uses standard `virtualisation.oci-containers` with the docker backend to deploy `firefly-db` (postgres), `firefly` (core), and `firefly-importer` on a dedicated, automatically provisioned `firefly-net` bridge network. It properly hooks up the ports to Traefik via `configuration.nix` dynamic services. Data is mapped to `/srv/firefly` and inherits existing `/srv` persistence and backup rules.

---
*PR created automatically by Jules for task [12726614788799044565](https://jules.google.com/task/12726614788799044565) started by @pniedzwiedzinski*