### PR TITLE
Update Firefly database password hashes

### DIFF
--- a/systems/x86_64-linux/srv3/firefly.nix
+++ b/systems/x86_64-linux/srv3/firefly.nix
@@ -13,7 +13,7 @@
       environment = {
         POSTGRES_USER = "firefly";
         POSTGRES_DB = "firefly";
-        POSTGRES_PASSWORD = "abf67942a6ea9c60cc8e7be054aef166";
+        POSTGRES_PASSWORD = "498eb837f7cb82f7fe7ff7a6011a064d";
       };
       extraOptions = [
         "--pull=always"
@@ -33,7 +33,7 @@
         DB_PORT = "5432";
         DB_DATABASE = "firefly";
         DB_USERNAME = "firefly";
-        DB_PASSWORD = "abf67942a6ea9c60cc8e7be054aef166";
+        DB_PASSWORD = "498eb837f7cb82f7fe7ff7a6011a064d";
         APP_KEY = "base64:uKamfqOYBbPEE7eGxTfarCWLRdsyy/VkVzIg3wKLb18=";
         TRUSTED_PROXIES = "**";
         SITE_OWNER = "patryk@niedzwiedzinski.cyou";


### PR DESCRIPTION
This updates the `POSTGRES_PASSWORD` and `DB_PASSWORD` variables in `systems/x86_64-linux/srv3/firefly.nix` with the full string hashes as specified by the user.

---
*PR created automatically by Jules for task [8126960479214257349](https://jules.google.com/task/8126960479214257349) started by @pniedzwiedzinski*