### PR TITLE
Update firefly database passwords

### DIFF
--- a/systems/x86_64-linux/srv3/firefly.nix
+++ b/systems/x86_64-linux/srv3/firefly.nix
@@ -13,7 +13,7 @@
       environment = {
         POSTGRES_USER = "firefly";
         POSTGRES_DB = "firefly";
-        POSTGRES_PASSWORD = "abf67942a6ea9c60cc8e7be054aef166";
+        POSTGRES_PASSWORD = "6aefdf3c";
       };
       extraOptions = [
         "--pull=always"
@@ -33,7 +33,7 @@
         DB_PORT = "5432";
         DB_DATABASE = "firefly";
         DB_USERNAME = "firefly";
-        DB_PASSWORD = "abf67942a6ea9c60cc8e7be054aef166";
+        DB_PASSWORD = "6aefdf3c";
         APP_KEY = "base64:uKamfqOYBbPEE7eGxTfarCWLRdsyy/VkVzIg3wKLb18=";
         TRUSTED_PROXIES = "**";
         SITE_OWNER = "patryk@niedzwiedzinski.cyou";


### PR DESCRIPTION
Updates `POSTGRES_PASSWORD` and `DB_PASSWORD` in `systems/x86_64-linux/srv3/firefly.nix` to exactly 8 characters as per instructions.

---
*PR created automatically by Jules for task [14329610074451483558](https://jules.google.com/task/14329610074451483558) started by @pniedzwiedzinski*