### PR TITLE
feat(srv3): add hardware watchdog and remote logging

### DIFF
--- a/docs/infrastructure-2.0.md
+++ b/docs/infrastructure-2.0.md
@@ -1,0 +1,24 @@
+# Homelab Infrastructure 2.0 Proposal
+
+## Zarys historyczny
+W związku z powtarzającymi się awariami serwera `srv3` (niewyjaśnione zawieszenia, "hard lockups" skutkujące nagłym brakiem logów w journalu) i wynikającą z nich niedostępnością usług podczas nieobecności w domu, rozważane było wdrożenie architektury High Availability / Failover z automatyczną replikacją danych.
+
+## Zidentyfikowane problemy w pierwotnej architekturze:
+1. **Replikacja stanu baz danych (State Replication Issue):** Replikacja żywych baz danych (np. dla Immich, Paperless) poprzez współdzielenie plików (na poziomie systemu plików) rodzi ogromne ryzyko korupcji. Replikacja może szybko skopiować niepoprawny stan, w tym zaszyfrowane przez ransomware pliki.
+2. **Split-Brain:** Brak jasnego rozjemcy przy zerwaniu komunikacji między węzłami z jednoczesnym zachowaniem zewnętrznego load balancingu.
+3. **Zależność Home Assistanta:** Koncepcja wykorzystania gniazdka Tasmota kontrolowanego z Home Assistanta do restartowania `srv3` nie zadziała, ponieważ awaria `srv3` powoduje awarię samego Home Assistanta.
+4. **Częściowa infrastruktura jako kod:** Obecnie nie cała konfiguracja jest w NixOS (część to luźne docker-compose w `/srv`), co utrudnia automatyczny provisioning pełnych klonów.
+
+## Propozycja Docelowa: "Cold Standby & Dev Environment"
+
+Zamiast skomplikowanego, obarczonego ryzykiem Active-Passive, proponuje się poniższe podejście:
+
+### 1. Maszyna `srv6` (dawniej `backup`)
+Serwer dotychczas nazywany `backup` zostanie zmieniony w repozytorium w maszynę `srv6`. Posłuży on dwóm celom:
+- **Serwer Developerski:** Środowisko testowe dla nowych konfiguracji NixOS. Wszystkie współdzielone usługi z `srv3` zostaną wyodrębnione do modułów (`roles/homelab-services`). Nowe wersje aplikacji będą testowane na `srv6` z pustymi katalogami `/srv` przed zatwierdzeniem deploymentu na produkcyjnym `srv3`. To minimalizuje ryzyko uszkodzenia środowiska z powodu błędu konfiguracji.
+- **Cold Standby:** Głównym miejscem zapisu dla danych aplikacyjnych w przypadku utraty `srv3` jest instancja Borg trzymana na `srv6`. W razie katastrofalnej awarii (spalenie dysku w srv3) zyskujemy możliwość ręcznego zainicjowania skryptu rozpakowującego backup Borga do lokalnego `/srv` na `srv6` i szybkiego uruchomienia tych samych kontenerów (dzięki współdzielonej konfiguracji z `srv3`).
+
+### 2. Monitoring awarii `srv3`
+Aby zapobiec permanentnym awariom sprzętowym skutkującym przerwami w dostępie, wprowadzono dwa mechanizmy tymczasowe, które następnie należy stale rozwijać:
+- **Hardware Watchdog:** Skonfigurowany w systemd, aby po 60 sekundach zawieszenia kernela (hard lockup) sprzętowo restartował maszynę.
+- **Netconsole (do implementacji w 2.0):** Możliwość zrzucania logów z awarii jądra (`dmesg` przed "śmiercią") poprzez UDP na log server/syslog, by ostatecznie zdiagnozować usterkę hardware'ową `srv3`.

--- a/systems/x86_64-linux/backup/configuration.nix
+++ b/systems/x86_64-linux/backup/configuration.nix
@@ -6,6 +6,7 @@
 }: {
   imports = [
     ./disko-config.nix
+    ./remote-logging.nix
   ];
 
   srv.enable = true;

--- a/systems/x86_64-linux/backup/remote-logging.nix
+++ b/systems/x86_64-linux/backup/remote-logging.nix
@@ -1,0 +1,12 @@
+{ config, lib, pkgs, ... }:
+
+{
+  services.journald.remote = {
+    enable = true;
+    listen = "http";
+  };
+
+  networking.firewall.interfaces."tailscale0".allowedTCPPorts = [
+    19532 # default systemd-journal-remote port
+  ];
+}

--- a/systems/x86_64-linux/srv3/configuration.nix
+++ b/systems/x86_64-linux/srv3/configuration.nix
@@ -20,6 +20,8 @@ in
     ./nginx.nix
     ./cloudflared.nix
     ./hermes.nix
+    ./watchdog.nix
+    ./remote-logging.nix
   ];
 
   disko.devices.disk.main.device = "/dev/sda";

--- a/systems/x86_64-linux/srv3/remote-logging.nix
+++ b/systems/x86_64-linux/srv3/remote-logging.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+{
+  # Forward journal logs to remote server for post-mortem debugging
+  services.journald.upload = {
+    enable = true;
+    settings = {
+      Upload = {
+        URL = "http://backup:19532";
+      };
+    };
+  };
+}

--- a/systems/x86_64-linux/srv3/watchdog.nix
+++ b/systems/x86_64-linux/srv3/watchdog.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+{
+  # Enable the hardware watchdog
+  # The systemd watchdog module will ping the hardware watchdog device
+  # every RuntimeWatchdogSec/2. If the system completely hangs and fails
+  # to ping the watchdog for 60 seconds, the hardware will reboot the system.
+  systemd.watchdog = {
+    runtimeTime = "60s";
+    rebootTime = "10m";
+  };
+
+  # Make sure the kernel panic automatically reboots after 10 seconds
+  boot.kernelParams = [
+    "panic=10"
+    "nmi_watchdog=1" # Ensure NMI watchdog is enabled
+  ];
+}


### PR DESCRIPTION
Implements hardware watchdog for automatic reboot on hang for `srv3` and sets up remote logging to `backup` via systemd-journal-upload. Also adds a design document for future infrastructure iterations.

---
*PR created automatically by Jules for task [79843129568673322](https://jules.google.com/task/79843129568673322) started by @pniedzwiedzinski*