### PR TITLE
feat: Add AirLLM support on srv5

### DIFF
--- a/systems/x86_64-linux/srv5/airllm.nix
+++ b/systems/x86_64-linux/srv5/airllm.nix
@@ -1,0 +1,86 @@
+{
+  pkgs,
+  lib,
+  ...
+}: {
+  virtualisation.oci-containers.containers."airllm" = {
+    image = "airllm:latest";
+    autoStart = true;
+    ports = [
+      "5000:5000/tcp"
+    ];
+    environment = {
+      MODEL_ID = "Qwen/Qwen3.5-4B";
+      MAX_LENGTH = "128";
+      COMPRESSION = "4bit";
+    };
+    volumes = [
+      "airllm_hf-cache:/root/.cache/huggingface:rw"
+    ];
+    extraOptions = [
+      "--device=nvidia.com/gpu=all"
+      "--network-alias=airllm"
+      "--network=airllm_default"
+    ];
+    dependsOn = [ "build-airllm-image" ];
+    log-driver = "journald";
+  };
+
+  systemd.services."docker-airllm" = {
+    serviceConfig = {
+      Restart = lib.mkOverride 90 "always";
+    };
+    partOf = [
+      "docker-compose-airllm-root.target"
+    ];
+    wantedBy = [
+      "docker-compose-airllm-root.target"
+    ];
+  };
+
+  systemd.services."build-airllm-image" = {
+    path = [ pkgs.docker ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      cd /etc/nixos/systems/x86_64-linux/srv5/airllm && docker build -t airllm:latest .
+    '';
+    wantedBy = ["multi-user.target"];
+  };
+
+  systemd.services."docker-network-airllm_default" = {
+    path = [pkgs.docker];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStop = "docker network rm airllm_default";
+    };
+    script = ''
+      docker network inspect airllm_default || docker network create airllm_default
+    '';
+    partOf = ["docker-compose-airllm-root.target"];
+    wantedBy = ["docker-compose-airllm-root.target"];
+  };
+
+  systemd.services."docker-volume-airllm_hf-cache" = {
+    path = [pkgs.docker];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      docker volume inspect airllm_hf-cache || docker volume create airllm_hf-cache
+    '';
+    partOf = ["docker-compose-airllm-root.target"];
+    wantedBy = ["docker-compose-airllm-root.target"];
+  };
+
+  systemd.targets."docker-compose-airllm-root" = {
+    unitConfig = {
+      Description = "Root target for airllm.";
+    };
+    wantedBy = ["multi-user.target"];
+  };
+}

--- a/systems/x86_64-linux/srv5/airllm/Dockerfile
+++ b/systems/x86_64-linux/srv5/airllm/Dockerfile
@@ -1,0 +1,9 @@
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+
+WORKDIR /app
+
+RUN pip install airllm flask pydantic bitsandbytes
+
+COPY server.py ./server.py
+
+ENTRYPOINT ["python", "/app/server.py"]

--- a/systems/x86_64-linux/srv5/airllm/server.py
+++ b/systems/x86_64-linux/srv5/airllm/server.py
@@ -1,0 +1,216 @@
+from flask import Flask, request, jsonify, Response, stream_with_context
+from pydantic import BaseModel
+from typing import List, Optional
+from airllm import AutoModel
+
+import json
+import time
+import os
+
+# Initialize Flask app
+app = Flask(__name__)
+model = None
+
+# Read from the environment or use defaults
+MAX_LENGTH = int(os.getenv('MAX_LENGTH', 128))
+PORT = int(os.getenv('PORT', 5000))
+MODEL_ID = os.getenv('MODEL_ID', "Qwen/Qwen3.5-4B")
+COMPRESSION = os.getenv('COMPRESSION', '4bit')
+
+# Request model schema for `/v1/completions`
+class CompletionRequestBody(BaseModel):
+    prompt: str
+    max_tokens: Optional[int] = 20
+    temperature: Optional[float] = 1.0
+    top_p: Optional[float] = 1.0
+    n: Optional[int] = 1
+    stop: Optional[List[str]] = None
+
+# Request model schema for `/v1/chat/completions`
+class ChatCompletionRequestBody(BaseModel):
+    messages: List[dict]
+    max_tokens: Optional[int] = 128
+    temperature: Optional[float] = 1.0
+    top_p: Optional[float] = 1.0
+    n: Optional[int] = 1
+    stop: Optional[List[str]] = None
+
+# `/v1/models` endpoint
+@app.route("/v1/models", methods=["GET"])
+def list_models():
+    response = {
+        "object": "list",
+        "data": [
+            {
+                "id": MODEL_ID,
+                "object": "model",
+                "created": 1234567890,
+                "owned_by": "organization",
+                "permission": []
+            }
+        ]
+    }
+    return jsonify(response)
+
+# `/v1/chat/completions` endpoint with streaming support
+@app.route("/v1/chat/completions", methods=["POST"])
+def chat_completions():
+    try:
+        # Parse the incoming request
+        data = request.get_json()
+        req_body = ChatCompletionRequestBody(**data)
+
+        prompt = model.tokenizer.apply_chat_template(
+            req_body.messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+        # Tokenize the input prompt
+        input_tokens = model.tokenizer(
+            [prompt],
+            return_tensors="pt",
+            return_attention_mask=False,
+            truncation=True,
+            max_length=MAX_LENGTH,
+            padding=False
+        )
+
+        input_ids = input_tokens['input_ids'].cuda()
+
+        # Generate the output sequence with streaming
+        gen_output = model.generate(
+            input_ids,
+            max_new_tokens=req_body.max_tokens,
+            use_cache=True,
+            return_dict_in_generate=True,
+            output_scores=True,
+            pad_token_id=model.tokenizer.eos_token_id
+        )
+
+        # Extract the generated tokens (when return_dict_in_generate=True)
+        generated_sequences = gen_output['sequences']
+
+        def generate_stream():
+            # Decode tokens one by one and stream the response
+            for i in range(input_ids.shape[1], generated_sequences.shape[1]):
+                token = generated_sequences[:, i:i+1]
+                output_text = model.tokenizer.decode(token[0], skip_special_tokens=True)
+
+                if output_text.strip():  # Only stream non-empty content
+                    chunk = {
+                        "id": f"chatcmpl-xxxx",
+                        "object": "chat.completion.chunk",
+                        "created": int(time.time()),
+                        "model": MODEL_ID,
+                        "system_fingerprint": "fp_airllm",
+                        "choices": [
+                            {
+                                "delta": {
+                                    "role": "assistant",
+                                    "content": output_text
+                                },
+                                "index": 0,
+                                "finish_reason": None
+                            }
+                        ]
+                    }
+                    yield f"data: {json.dumps(chunk)}\n\n"
+
+            # Stream the final stop signal
+            final_chunk = {
+                "id": f"chatcmpl-xxxx",
+                "object": "chat.completion.chunk",
+                "created": int(time.time()),
+                "model": MODEL_ID,
+                "system_fingerprint": "fp_airllm",
+                "choices": [
+                    {
+                        "delta": {},
+                        "index": 0,
+                        "finish_reason": "stop"
+                    }
+                ]
+            }
+            yield f"data: {json.dumps(final_chunk)}\n\n"
+
+        return Response(stream_with_context(generate_stream()), content_type='text/event-stream')
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+# `/v1/completions` endpoint
+@app.route("/v1/completions", methods=["POST"])
+def completions():
+    try:
+        # Parse the incoming request
+        data = request.get_json()
+        req_body = CompletionRequestBody(**data)
+
+        # Tokenize the input prompt
+        input_tokens = model.tokenizer(
+            [req_body.prompt],
+            return_tensors="pt",
+            return_attention_mask=False,
+            truncation=True,
+            max_length=MAX_LENGTH,
+            padding=False
+        )
+
+        input_ids = input_tokens['input_ids'].cuda()
+
+        # Generate the output sequence
+        gen_output = model.generate(
+            input_ids,
+            max_new_tokens=req_body.max_tokens,
+            use_cache=True,
+            return_dict_in_generate=True,
+            output_scores=True,
+            pad_token_id=model.tokenizer.eos_token_id
+        )
+
+        # Extract the generated tokens
+        generated_sequences = gen_output['sequences']
+
+        output_text = model.tokenizer.decode(generated_sequences[0][input_ids.shape[1]:], skip_special_tokens=True)
+
+        response = {
+            "id": f"cmpl-xxxx",
+            "object": "text_completion",
+            "created": int(time.time()),
+            "model": MODEL_ID,
+            "choices": [
+                {
+                    "text": output_text,
+                    "index": 0,
+                    "logprobs": None,
+                    "finish_reason": "length"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": input_ids.shape[1],
+                "completion_tokens": generated_sequences.shape[1] - input_ids.shape[1],
+                "total_tokens": generated_sequences.shape[1]
+            }
+        }
+        return jsonify(response)
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+if __name__ == "__main__":
+    print(f"Config: PORT={PORT} MODEL={MODEL_ID} MAX_LENGTH={MAX_LENGTH} COMPRESSION={COMPRESSION}")
+    print(f"Loading model...")
+
+    if COMPRESSION == 'none':
+        model = AutoModel.from_pretrained(
+            MODEL_ID
+        )
+    else:
+        model = AutoModel.from_pretrained(
+            MODEL_ID,
+            compression=COMPRESSION
+        )
+
+    print(f"Starting server on port {PORT}")
+    app.run(host="0.0.0.0", port=PORT)

--- a/systems/x86_64-linux/srv5/configuration.nix
+++ b/systems/x86_64-linux/srv5/configuration.nix
@@ -3,6 +3,7 @@
     ./disko-config.nix
     ./nvidia_gpu.nix
     ./ollama.nix
+    ./airllm.nix
     ../doas.nix
 
     ./docker-compose.nix

--- a/systems/x86_64-linux/srv5/ollama.nix
+++ b/systems/x86_64-linux/srv5/ollama.nix
@@ -31,5 +31,5 @@
     };
   };
 
-  networking.firewall.allowedTCPPorts = [80 11434];
+  networking.firewall.allowedTCPPorts = [80 11434 5000];
 }


### PR DESCRIPTION
Dodaje usługę AirLLM (OpenAI-kompatybilny serwer dla modelu) w kontenerze Docker na `srv5`.
Skonfigurowano pobieranie i budowanie obrazu z dedykowanego Dockerfile wewnątrz nowego modułu w systemie NixOS. Serwer Flask nasłuchuje na porcie 5000 (który jest odpowiednio udostępniony w regułach firewalla).
Dodatkowo skonfigurowano mechanizmy `systemd` z systemem targets i oneshots podobnie jak jest to w Ollamie.

---
*PR created automatically by Jules for task [2634690699992834792](https://jules.google.com/task/2634690699992834792) started by @pniedzwiedzinski*