### PR TITLE
feat(srv3): add watchtower to hermes.nix

### DIFF
--- a/systems/x86_64-linux/srv3/hermes.nix
+++ b/systems/x86_64-linux/srv3/hermes.nix
@@ -57,6 +57,21 @@
     dependsOn = ["hermes"];
   };
 
+  virtualisation.oci-containers.containers.watchtower = {
+    autoStart = true;
+    image = "containrrr/watchtower:latest";
+    cmd = [
+      "--cleanup"
+      "--schedule" "0 0 4 * * *"
+      "--rolling-restart"
+    ];
+    volumes = ["/var/run/docker.sock:/var/run/docker.sock"];
+    extraOptions = [
+      "--pull=always"
+      "--network=hermes-net"
+    ];
+  };
+
   # Docker network for Hermes containers
   systemd.services."docker-network-hermes-net" = {
     path = [pkgs.docker];


### PR DESCRIPTION
Adds a watchtower container to `hermes.nix` in the `srv3` NixOS configuration to automate updates for OCI containers. Ensures the proper configuration as requested by the user.

---
*PR created automatically by Jules for task [13489595331733012678](https://jules.google.com/task/13489595331733012678) started by @pniedzwiedzinski*